### PR TITLE
Fix vertical parallax and take insets into account

### DIFF
--- a/JVParallax/JVParallaxView/JVParallaxView.swift
+++ b/JVParallax/JVParallaxView/JVParallaxView.swift
@@ -9,14 +9,14 @@
 import UIKit
 
 @IBDesignable class JVParallaxView: UIView {
-
+    
     //MARK: - Interface builder vars
     @IBOutlet var viewToParallax: UIView? {
         didSet {
             self.updateForView()
         }
     }
-
+    
     /** This value is to determine a ratio at which the viewToParallax is out of bounds of this view.
      The value is from 0 to 1 and represent a percentage of this view width|height */
     @IBInspectable var maxParallax: CGFloat = 0.25 {
@@ -25,7 +25,7 @@ import UIKit
         }
     }
     
-    /** This is the value in pourcentage of the advancement of the parallax. 
+    /** This is the value in pourcentage of the advancement of the parallax.
      Value between 0 to 1. 0 means the viewToParallax will be to the left|top of this view, a value of 0.5 means it is centered in this view and a value of 1 means it will be to the right|bottom of this view. */
     @IBInspectable var value: CGFloat = 0.0 {
         didSet {
@@ -33,7 +33,12 @@ import UIKit
         }
     }
     
-    @IBInspectable var isHorizontal: Bool = true
+    @IBInspectable var isHorizontal: Bool = true {
+        didSet {
+            self.updateStartPoint()
+            self.updateValue()
+        }
+    }
     
     //MARK: - Private vars
     private var centerXConstraint: NSLayoutConstraint!
@@ -54,7 +59,7 @@ import UIKit
         super.init(frame: frame)
         self.initialize()
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.initialize()
@@ -69,6 +74,8 @@ import UIKit
     private func updateForView() {
         guard let viewToParallax = self.viewToParallax else { return }
         
+        viewToParallax.removeFromSuperview()
+        
         let width = NSLayoutConstraint(item: viewToParallax, attribute: .Width, relatedBy: .Equal, toItem: self, attribute: .Width, multiplier: 1, constant: 0)
         let height = NSLayoutConstraint(item: viewToParallax, attribute: .Height, relatedBy: .Equal, toItem: self, attribute: .Height, multiplier: 1, constant: 0)
         self.centerXConstraint = NSLayoutConstraint(item: self, attribute: .CenterX, relatedBy: .Equal, toItem: viewToParallax, attribute: .CenterX, multiplier: 1, constant: 0)
@@ -78,6 +85,7 @@ import UIKit
         self.addSubview(viewToParallax)
         
         NSLayoutConstraint.activateConstraints([width, height, self.centerXConstraint, self.centerYConstraint])
+        self.layoutIfNeeded()
         
         self.updateStartPoint()
     }

--- a/JVParallax/JVScrollViewParallaxBehavior/JVScrollViewParallaxBehavior.swift
+++ b/JVParallax/JVScrollViewParallaxBehavior/JVScrollViewParallaxBehavior.swift
@@ -14,6 +14,8 @@ class JVScrollViewParallaxBehavior: NSObject, UIScrollViewDelegate {
     
     @IBOutlet var parallaxViews: [JVParallaxView]?
     
+    @IBInspectable var isHorizontal: Bool = true
+    
     func scrollViewDidScroll(scrollView: UIScrollView) {
         guard let scrollView = self.scrollView else { print("You forgot to set the scrollView to your behavior"); return }
         guard let parallaxViews = self.parallaxViews else { return }
@@ -22,13 +24,36 @@ class JVScrollViewParallaxBehavior: NSObject, UIScrollViewDelegate {
             guard let superView = parallaxView.superview else { return }
             
             let parallaxViewFramInScrollView = scrollView.convertRect(parallaxView.frame, fromView: superView)
-            let visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, scrollView.frame.width, scrollView.frame.height)
+
+            let visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, scrollView.frame.width * getWidthMultiplier(scrollView), scrollView.frame.height * getHeightMultiplier(scrollView))
             let intersectRect = CGRectIntersection(parallaxViewFramInScrollView, visibleRect)
             
             guard intersectRect != CGRectNull else { return }
-            let percentageValueShowed = (intersectRect.width/parallaxViewFramInScrollView.width)/2 + ((intersectRect.origin.x - parallaxViewFramInScrollView.origin.x)/parallaxViewFramInScrollView.width)
+            let sizeValue = isHorizontal ? parallaxViewFramInScrollView.width : parallaxViewFramInScrollView.height
+            let originValue = isHorizontal ? parallaxViewFramInScrollView.origin.x : parallaxViewFramInScrollView.origin.y
+            
+            let intersectSizeValue = isHorizontal ? intersectRect.width : intersectRect.height
+            let intersectOriginValue = isHorizontal ? intersectRect.origin.x : intersectRect.origin.y
+            let percentageValueShowed = (intersectSizeValue/sizeValue)/2 + ((intersectOriginValue - originValue)/sizeValue)
             
             parallaxView.value = percentageValueShowed
         }
+    }
+    
+    // MARK: - Calculation of size multipliers by taking account insets 
+    
+    private func getHeightMultiplier(scrollView : UIScrollView) -> CGFloat {
+        return getMultiplier(scrollView.contentInset.top, offset: scrollView.contentOffset.y)
+    }
+    
+    private func getWidthMultiplier(scrollView : UIScrollView) -> CGFloat {
+        return getMultiplier(scrollView.contentInset.left, offset: scrollView.contentOffset.x)
+    }
+    
+    private func getMultiplier(inset : CGFloat, offset : CGFloat) -> CGFloat {
+        guard inset > 0 else { return 1 }
+        var multiplier = ((inset + offset))/inset
+        multiplier = multiplier > 1 ? 1 : multiplier
+        return 1 - multiplier
     }
 }


### PR DESCRIPTION
The vertical parallax wasn't fully implemented so I finished it.

I needed to take into account the insets of the scrollView for the animation so I modified the visible rect calculation to do that. If you have no insets it doesn't have any impact.
